### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/bomgames06/streaming-next/security/code-scanning/1](https://github.com/bomgames06/streaming-next/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. Since the workflow only needs to read the repository contents to perform tasks like checking out the code and running tests, we will set `contents: read`. This ensures the workflow has the minimal permissions required to function correctly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
